### PR TITLE
fix: correct time format

### DIFF
--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -368,7 +368,7 @@ components:
   FeedInfo:
     autoFetch: Récupération automatique
     autoPublish: Publication automatique
-    dateFormat: MM JJ, AAAA
+    dateFormat: DD.MM.YYYY
     deployable: Déployable
     edit: Editer
     lastUpdatedDate: Dernière mise à jour %date%
@@ -420,7 +420,7 @@ components:
     latestVersion: Dernière version
     status: Statut
   FeedSourceTableRow:
-    dateFormat: MM JJ, AAAA
+    dateFormat: DD.MM.YYYY
     expired: Expiré il y a %duration%
     lastUpdated: Dernière mise à jour il y à %lastVersionUpdate%
     none: Aucun


### PR DESCRIPTION
Dateformat wasn't correct:

Before:
![image](https://github.com/user-attachments/assets/f3ddae41-8c4f-4471-adfc-1d1d82194bd6)

After:
![image](https://github.com/user-attachments/assets/34a614d6-f3a7-4bf5-a053-d51dcf2eab61)

_ps: the feed isn't the same on before/after, this is why dates aren't exactly the same_
